### PR TITLE
Fix displaying Grid total Power when grid_ct_power_total only given

### DIFF
--- a/src/cards/compact/grid.ts
+++ b/src/cards/compact/grid.ts
@@ -212,7 +212,7 @@ export class Grid {
 				? svg`
 					<a href="#" @click=${(e) => Utils.handlePopup(e, config.entities.grid_ct_power_total)}>
 						<text id="grid_total_power" x="140" y="220"
-							  display="${config.entities.grid_ct_power_172 === 'none' ? 'none' : ''}"
+							  display="${config.entities.grid_ct_power_total === 'none' ? 'none' : ''}"
 							  class="${data.largeFont !== true ? 'st14' : 'st4'} st8" fill="${data.gridColour}">
 							${config.grid.auto_scale
 								? `${config.grid.show_absolute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
<!--- If the change is breaking, it must be detailed what breaks and what users need to do to fix it -->
Fix displaying Grid total Power when grid_ct_power_total only given
## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. e.g. fixes #123 closes #123 -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version in `package.json` following [semver](https://semver.org/)

