### PR TITLE
you can specify the battery charge cut-off capacity using the soc_end_of_charge attribute. If for example you set your battery to charge up to 90% the card will correctly display charge time to this capacity. Expects a numeric value between 80 and 100 or sensor i.e. sensor.soc_end_of_charge  by slipx06 (sunsynk-power-flow-card#514)

### DIFF
--- a/src/cards/compact-card.ts
+++ b/src/cards/compact-card.ts
@@ -171,7 +171,7 @@ export const compactCard = (config: PowerFlowCardConfig, inverterImg: string, da
 
 						${Inverter.generateTimerInfo(data, config)}
 						${Inverter.generatePriorityLoad(data, config)}
-						${Inverter.generateInverterImage(data, inverterImg)}
+						${Inverter.generateInverterImage(data, config, inverterImg)}
 						${Inverter.generateInverterState(data, config)}
 						${Inverter.generateInverterLoad(data, config)}
 						${Inverter.generateInverterProgram(data)}

--- a/src/cards/compact/battery.ts
+++ b/src/cards/compact/battery.ts
@@ -164,11 +164,11 @@ export class Battery {
  			<svg id="battery-flow">
 				<path id="bat-line"
 					  d="M 239 250 L 239 ${y}" fill="none"
-					  stroke="${config.battery.dynamic_colour ? data.flowBatColour : data.batteryColour}" stroke-width="${data.batLineWidth}" stroke-miterlimit="10"
+					  stroke="${Battery.batteryColour(data, config)}" stroke-width="${data.batLineWidth}" stroke-miterlimit="10"
 					  pointer-events="stroke"/>
 				<circle id="power-dot-discharge" cx="0" cy="0"
 						r="${Math.min(2 + data.batLineWidth + Math.max(data.minLineWidth - 2, 0), 8)}"
-						fill="${data.batteryPower <= 0 ? 'transparent' : `${Battery.batteryColour(data, config)}}`}">
+						fill="${data.batteryPower <= 0 ? 'transparent' : `${Battery.batteryColour(data, config)}`}">
 					<animateMotion dur="${data.durationCur['battery']}s" repeatCount="indefinite"
 								   keyPoints="1;0" keyTimes="0;1" calcMode="linear">
 						<mpath xlink:href="#bat-line"/>
@@ -265,7 +265,7 @@ export class Battery {
 
 	static generateBatteryGradient(data: DataDto, config: PowerFlowCardConfig) {
 		const y =  Battery.showOuterBatteryBanks(config)?312.5 : 325.5;
-		return svg`
+		let bat = svg`
 			<svg xmlns="http://www.w3.org/2000/svg" id="bat" x="212.5"
 				 y="${y}" width="78.75"
 				 height="78.75" preserveAspectRatio="none"
@@ -307,5 +307,10 @@ export class Battery {
 					  d="${data.batteryCharge}"/>
 			</svg>		
 		`;
+		return config.battery.navigate?
+			svg` <a href="#" @click=${(e) => Utils.handleNavigation(e, config.battery.navigate)}>
+				${bat}
+			</a>`
+			: bat;
 	}
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,146 +1,168 @@
-import {unitOfEnergyConversionRules, UnitOfEnergyOrPower, UnitOfPower} from '../const';
+import { unitOfEnergyConversionRules, UnitOfEnergyOrPower, UnitOfPower } from '../const';
+import { navigate } from 'custom-card-helpers';
 
 export class Utils {
-    static toNum(val: string | number, decimals: number = -1, invert: boolean = false, abs: boolean = false): number {
-        let numberValue = Number(val);
-        if (Number.isNaN(numberValue)) {
-            return 0;
-        }
-        if (decimals >= 0) {
-            numberValue = parseFloat(numberValue.toFixed(decimals));
-        }
-        if (invert) {
-            numberValue *= -1;
-        }
-        if(abs) {
-          numberValue = Math.abs(numberValue);
-        }
-        return numberValue;
-    }
+	static toNum(val: string | number, decimals: number = -1, invert: boolean = false, abs: boolean = false): number {
+		let numberValue = Number(val);
+		if (Number.isNaN(numberValue)) {
+			return 0;
+		}
+		if (decimals >= 0) {
+			numberValue = parseFloat(numberValue.toFixed(decimals));
+		}
+		if (invert) {
+			numberValue *= -1;
+		}
+		if (abs) {
+			numberValue = Math.abs(numberValue);
+		}
+		return numberValue;
+	}
 
-    static convertValue(value, decimal = 2) {
-        decimal = Number.isNaN(decimal) ? 2 : decimal;
-        if (Math.abs(value) >= 1000000) {
-            return `${(value / 1000000).toFixed(decimal)} MW`;
-        } else if (Math.abs(value) >= 1000) {
-            return `${(value / 1000).toFixed(decimal)} kW`;
-        } else {
-            return `${Math.round(value)} W`;
-        }
-    }
+	static convertValue(value, decimal = 2) {
+		decimal = Number.isNaN(decimal) ? 2 : decimal;
+		if (Math.abs(value) >= 1000000) {
+			return `${(value / 1000000).toFixed(decimal)} MW`;
+		} else if (Math.abs(value) >= 1000) {
+			return `${(value / 1000).toFixed(decimal)} kW`;
+		} else {
+			return `${Math.round(value)} W`;
+		}
+	}
 
-    static convertValueNew(
-			value: string | number,
-			unit: UnitOfEnergyOrPower | string = '',
-			decimal: number = 2,
-			withUnit: boolean = true,
-    ):string {
-        decimal = isNaN(decimal) ? 2 : decimal;
-        const numberValue = Number(value);
-        if (isNaN(numberValue)) return Number(0).toFixed(decimal);
+	static convertValueNew(
+		value: string | number,
+		unit: UnitOfEnergyOrPower | string = '',
+		decimal: number = 2,
+		withUnit: boolean = true,
+	): string {
+		decimal = isNaN(decimal) ? 2 : decimal;
+		const numberValue = Number(value);
+		if (isNaN(numberValue)) return Number(0).toFixed(decimal);
 
-        const rules = unitOfEnergyConversionRules[unit];
-        if (!rules) {
-					if(withUnit) {
-						return `${this.toNum(numberValue, decimal)} ${unit}`
-					}
-						return `${this.toNum(numberValue, decimal)}`;
-        }
+		const rules = unitOfEnergyConversionRules[unit];
+		if (!rules) {
+			if (withUnit) {
+				return `${this.toNum(numberValue, decimal)} ${unit}`;
+			}
+			return `${this.toNum(numberValue, decimal)}`;
+		}
 
-        if (unit === UnitOfPower.WATT && Math.abs(numberValue) < 1000) {
-	        if(withUnit) {
-						return `${Math.round(numberValue)} ${unit}`;
-					}
-	        return `${Math.round(numberValue)}`;
-        }
+		if (unit === UnitOfPower.WATT && Math.abs(numberValue) < 1000) {
+			if (withUnit) {
+				return `${Math.round(numberValue)} ${unit}`;
+			}
+			return `${Math.round(numberValue)}`;
+		}
 
-        if (unit === UnitOfPower.KILO_WATT && Math.abs(numberValue) < 1) {
-	        if(withUnit) {
-						return `${Math.round(numberValue * 1000)} W`;
-					}
-	        return `${Math.round(numberValue * 1000)}`;
-        }
+		if (unit === UnitOfPower.KILO_WATT && Math.abs(numberValue) < 1) {
+			if (withUnit) {
+				return `${Math.round(numberValue * 1000)} W`;
+			}
+			return `${Math.round(numberValue * 1000)}`;
+		}
 
-        if (unit === UnitOfPower.MEGA_WATT && Math.abs(numberValue) < 1) {
-	        if(withUnit) {
-						return `${(numberValue * 1000).toFixed(decimal)} kW`;
-					}
-	        return `${(numberValue * 1000).toFixed(decimal)}`;
-        }
+		if (unit === UnitOfPower.MEGA_WATT && Math.abs(numberValue) < 1) {
+			if (withUnit) {
+				return `${(numberValue * 1000).toFixed(decimal)} kW`;
+			}
+			return `${(numberValue * 1000).toFixed(decimal)}`;
+		}
 
-        for (const rule of rules) {
-            if (Math.abs(numberValue) >= rule.threshold) {
-                const convertedValue = (numberValue / rule.divisor).toFixed(rule.decimal || decimal);
-		            if(withUnit) {
-									return `${convertedValue} ${rule.targetUnit}`;
-								}
-		            return `${convertedValue}`;
-            }
-        }
-
-		    if(withUnit) {
-					return `${numberValue.toFixed(decimal)} ${unit}`;
+		for (const rule of rules) {
+			if (Math.abs(numberValue) >= rule.threshold) {
+				const convertedValue = (numberValue / rule.divisor).toFixed(rule.decimal || decimal);
+				if (withUnit) {
+					return `${convertedValue} ${rule.targetUnit}`;
 				}
-		    return `${numberValue.toFixed(decimal)}`;
-    }
+				return `${convertedValue}`;
+			}
+		}
 
-    private static isPopupOpen = false;
-    static handlePopup(event, entityId) {
-        if (!entityId) {
-          return;
-        }
-        event.preventDefault();
-        this._handleClick(event, { action: 'more-info' }, entityId);
-      }
+		if (withUnit) {
+			return `${numberValue.toFixed(decimal)} ${unit}`;
+		}
+		return `${numberValue.toFixed(decimal)}`;
+	}
 
-      private static _handleClick(event, actionConfig, entityId) {
-        if (!event || !entityId) {
-          return;
-        }
+	private static isPopupOpen = false;
 
-        event.stopPropagation();
+	static handlePopup(event, entityId) {
+		if (!entityId) {
+			return;
+		}
+		event.preventDefault();
+		this._handleClick(event, { action: 'more-info' }, entityId);
+	}
 
-        // Handle different actions based on actionConfig
-        switch (actionConfig.action) {
-          case 'more-info':
-            this._dispatchMoreInfoEvent(event, entityId);
-            break;
-          default:
-            console.warn(`Action '${actionConfig.action}' is not supported.`);
-        }
-      }
+	static handleNavigation(event, navigationPath) {
+		if (!navigationPath) {
+			return;
+		}
+		event.preventDefault();
+		this._handleClick(event, { action: 'navigate', navigation_path: navigationPath }, null);
+	}
 
-      private static _dispatchMoreInfoEvent(event, entityId) {
+	private static _handleClick(event, actionConfig, entityId) {
+		if (!event || (!entityId && !actionConfig.navigation_path)) {
+			return;
+		}
 
-        if (Utils.isPopupOpen) {
-            return;
-          }
+		event.stopPropagation();
 
-        Utils.isPopupOpen = true;
+		// Handle different actions based on actionConfig
+		switch (actionConfig.action) {
+			case 'more-info':
+				this._dispatchMoreInfoEvent(event, entityId);
+				break;
+			case 'navigate':
+				this._handleNavigationEvent(event, actionConfig.navigation_path);
+				break;
+			default:
+				console.warn(`Action '${actionConfig.action}' is not supported.`);
+		}
+	}
 
-        const moreInfoEvent = new CustomEvent('hass-more-info', {
-          composed: true,
-          detail: { entityId },
-        });
+	private static _dispatchMoreInfoEvent(event, entityId) {
 
-        history.pushState({ popupOpen: true }, '', window.location.href);
+		if (Utils.isPopupOpen) {
+			return;
+		}
 
-        event.target.dispatchEvent(moreInfoEvent);
+		Utils.isPopupOpen = true;
 
-        const closePopup = () => {
+		const moreInfoEvent = new CustomEvent('hass-more-info', {
+			composed: true,
+			detail: { entityId },
+		});
 
-            if (Utils.isPopupOpen) {
-                //console.log(`Closing popup for entityId: ${entityId}`);
-                Utils.isPopupOpen = false;
+		history.pushState({ popupOpen: true }, '', window.location.href);
 
-                // Remove the event listener to avoid multiple bindings
-                window.removeEventListener('popstate', closePopup);
+		event.target.dispatchEvent(moreInfoEvent);
 
-                // Optionally, if your popup close logic doesn't trigger history.back(), call it manually
-                history.back();
-                }
-        };
+		const closePopup = () => {
 
-        window.addEventListener('popstate', closePopup, { once: true });
-      }
+			if (Utils.isPopupOpen) {
+				//console.log(`Closing popup for entityId: ${entityId}`);
+				Utils.isPopupOpen = false;
+
+				// Remove the event listener to avoid multiple bindings
+				window.removeEventListener('popstate', closePopup);
+
+				// Optionally, if your popup close logic doesn't trigger history.back(), call it manually
+				history.back();
+			}
+		};
+
+		window.addEventListener('popstate', closePopup, { once: true });
+	}
+
+	private static _handleNavigationEvent(event, navigationPath) {
+		// Perform the navigation action
+		if (navigationPath) {
+			navigate(event.target, navigationPath); // Assuming 'navigate' is a function available in your environment
+		} else {
+			console.warn('Navigation path is not provided.');
+		}
+	}
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -184,6 +184,8 @@
     "invert_load": "Invert Values",
     "shutdown_soc": "Shutdown SOC",
     "shutdown_soc_offgrid": "Shutdown SOC (Off Grid)",
+    "soc_end_of_charge": "SOC End of Charge",
+    "navigate": "Navigation Path",
     "energy": "Energy",
     "auto_scale": "Auto Scale",
     "three_phase": "Three Phase",

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
 	inverter: {
 		modern: boolean;
 		colour: string;
+		navigate: string;
 		autarky: AutarkyType;
 		model: InverterModel;
 		auto_scale: boolean;
@@ -86,9 +87,11 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
 		energy: any;
 		shutdown_soc: any;
 		shutdown_soc_offgrid: any;
+		soc_end_of_charge: any;
 		hide_soc: boolean;
 		invert_power: boolean;
 		colour: string;
+		navigate: string;
 		charge_colour: string;
 		show_daily: boolean;
 		animation_speed: number;
@@ -114,6 +117,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
 	}
 	solar: {
 		colour: string;
+		navigate: string;
 		mppts: number;
 		animation_speed: number;
 		max_power: number;
@@ -137,6 +141,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
 	}
 	load: {
 		colour: string;
+		navigate: string;
 		dynamic_colour: boolean;
 		aux_dynamic_colour: boolean;
 		dynamic_icon: boolean;
@@ -216,6 +221,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
 	}
 	grid: {
 		colour: string;
+		navigate: string;
 		grid_name: string;
 		label_daily_grid_buy: string;
 		label_daily_grid_sell: string;
@@ -368,6 +374,7 @@ export interface DataDto {
 	batteryBankTempState: CustomEntity[],
 	batteryBankEnergy: number[],
 	batteryBatteryBankColour: string[],
+	maximumSOC,
 	additionalLoad,
 	essIconSize,
 	essIcon: string,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
<!--- If the change is breaking, it must be detailed what breaks and what users need to do to fix it -->
you can specify the battery charge cut-off capacity using the soc_end_of_charge attribute. If for example you set your battery to charge up to 90% the card will correctly display charge time to this capacity. Expects a numeric value between 80 and 100 or sensor i.e. sensor.soc_end_of_charge  by slipx06 (sunsynk-power-flow-card#514)
## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. e.g. fixes #123 closes #123 -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version in `package.json` following [semver](https://semver.org/)

